### PR TITLE
Clean up backtick'd code to use $() syntax #6

### DIFF
--- a/bin/Attic/veegrep
+++ b/bin/Attic/veegrep
@@ -32,16 +32,16 @@ done
 
  get_title()
 {
-    TITLE=`head -n 3 $1 | tail -n 1`
+	TITLE=$(head -n 3 $1 | tail -n 1)
     echo $TITLE
 }
 
  get_body()
 {
-    # figure out how many lones file is for `tail` command
-    LC=`wc -l $1 | awk '{print $1}'`
+	# figure out how many lones file is for $(tail) command
+	LC=$(wc -l $1 | awk '{print $1}')
     BC=$(($LC-6))
-    echo `cat $1 | tail -n $BC`
+	cat $1 | tail -n $BC
     
 }
 

--- a/bin/vee
+++ b/bin/vee
@@ -13,13 +13,13 @@ FORMAT=html
 INDEX=vee.html
 DIR=.vee
 DRAFT=${DIR}/.vee.tmp.$$
-DATE=`date`
-YEAR=`date "+%Y"`
-TIME=`date "+%Y-%m-%dT%H:%M:%S"`
-SEC=`date "+%s"`
+DATE=$(date)
+YEAR=$(date "+%Y")
+TIME=$(date "+%Y-%m-%dT%H:%M:%S")
+SEC=$(date "+%s")
 TITLE=
 DEFAULT_TITLE="Entry #${SEC}";
-HEADERTXT=  # text or `cat some.header.txt` 
+HEADERTXT=  # text or $(cat some.header.txt)
 FOOTERTXT="Powered by <a href=\"http://www.0x743.com/vee\">vee</a><br/>Copyright &copy; 2006-${YEAR}"  
 TOP_TPL=./vee-top.tpl
 BOT_TPL=./vee-bottom.tpl
@@ -28,7 +28,7 @@ USE_EDITOR=1
 LISTENSTDIN=0
 SORT_NEWEST="sort -t. -nr"         # sorts all new to old 
 SORT_OLDEST="sort -t. -r"          # sorts all old to new
-PUBLISHED=`date "+%m/%d/%Y"`       # date formated for index page entry
+PUBLISHED=$(date "+%m/%d/%Y")       # date formated for index page entry
 OUTPUT_TOP=output_top
 OUTPUT_BOT=output_bottom
 
@@ -209,7 +209,7 @@ CUSTOM_SETUP=default_setup
   echo "3. Patches are welcome; the goal is not more feature bloat, but a nicer       "
   echo "   way of dealing with standard in, etc would be welcomed.                    " 
   echo "                                                                              " 
-  echo `disclaimer` 
+  disclaimer 
   exit 1
 }
 
@@ -217,7 +217,7 @@ CUSTOM_SETUP=default_setup
  default_update_index() 
 { echo "<!-- ;${SEC}; -->${PUBLISHED}:<a href=\"${DIR}/${SEC}.${TIME}.${FORMAT}\"> ${TITLE}</a>" >> ${INDEX}
   if [ -n "${SUMMARY}" ]; then
-    SEC=`expr $SEC - 1`
+	SEC=$(expr $SEC - 1)
     echo "<!-- ;${SEC}; -->${SUMMARY}" >> ${INDEX}
   fi
 }
@@ -325,7 +325,7 @@ CUSTOM_SETUP=default_setup
 }
 
  reformat_all()
-{ FILES=`ls -c ${DIR}/*.raw | ${SORT_OLDEST}`
+{ FILES=$(ls -c ${DIR}/*.raw | ${SORT_OLDEST})
    for RAW in $FILES; do
      # From: Randall R Schulz <rrschulz at cris dot com>
      FULLNAME="${RAW}"
@@ -340,44 +340,44 @@ CUSTOM_SETUP=default_setup
 }
 
  newest_first() 
-{ FILES=`ls -c ${DIR}/*.raw | ${SORT_NEWEST}`
+{ FILES=$(ls -c ${DIR}/*.raw | ${SORT_NEWEST})
   echo ${FILES}
 }
 
  list_newest_first()
-{ FILES=`newest_first`
+{ FILES=$(newest_first)
   COUNT=1
   for FILE in ${FILES}; do
      FULLNAME="${FILE}"
      DIR="${FULLNAME%/*}"
      FILE="${FULLNAME##*/}"
      MAXBASE="${FILE%.*}"
-     TITLE=`head -n 3 ${DIR}/${FILE} | tail -n 1` 
+	 TITLE=$(head -n 3 ${DIR}/${FILE} | tail -n 1) 
      printf "%7d)  " $COUNT
      echo ${MAXBASE} ::  ${TITLE}
-     COUNT=`expr $COUNT + 1`
+	 COUNT=$(expr $COUNT + 1)
   done
 }
 
  oldest_first()
-{ FILES=`ls -c ${DIR}/*.raw | ${SORT_OLDEST}`
+{ FILES=$(ls -c ${DIR}/*.raw | ${SORT_OLDEST})
   echo ${FILES}
 }
 
  list_oldest_first()
-{ FILES=`oldest_first`
+{ FILES=$(oldest_first)
   for FILE in ${FILES}; do
      FULLNAME="${FILE}"
      DIR="${FULLNAME%/*}"
      FILE="${FULLNAME##*/}"
      MAXBASE="${FILE%.*}"
-     TITLE=`head -n 3 ${DIR}/${FILE} | tail -n 1` 
+	 TITLE=$(head -n 3 ${DIR}/${FILE} | tail -n 1) 
      echo ${MAXBASE} ::  ${TITLE}
   done
 }
 
  get_path2post()
-{ FILES=`ls -c ${DIR}/*.raw | ${SORT_NEWEST}`
+{ FILES=$(ls -c ${DIR}/*.raw | ${SORT_NEWEST})
   GOAL=${1}
   COUNT=1
   for FILE in ${FILES}; do
@@ -389,7 +389,7 @@ CUSTOM_SETUP=default_setup
      echo ${MAXBASE}
      break
     fi
-    COUNT=`expr ${COUNT} + 1`
+	COUNT=$(expr ${COUNT} + 1)
   done
 }
 
@@ -400,15 +400,15 @@ CUSTOM_SETUP=default_setup
     echo "Can't find index, \"${INDEX}\""
     die_cleanly
   fi
-  FILES=`newest_first`
+  FILES=$(newest_first)
   for FILE in ${FILES}; do
      FULLNAME="${FILE}"
      DIR="${FULLNAME%/*}"
      FILE="${FULLNAME##*/}"
      MAXBASE="${FILE%.*}"
-     ENTRY=`grep "$MAXBASE" $INDEX`
+	 ENTRY=$(grep "$MAXBASE" $INDEX)
      if [ -z "${ENTRY}" ]; then
-       COUNT=`expr $COUNT + 1`
+	   COUNT=$(expr $COUNT + 1)
        if [ $LEVEL -eq 1 ]; then
          echo "$DIR/$FILE (not really purged, use -P for realz)"
        elif [ $LEVEL -eq 2 ]; then
@@ -448,7 +448,7 @@ while getopts 'f:m:t:T:c:d:i:IbB:hRr:lL:novx:X:Pps:' option; do
          echo "${OPTARG}" is not a directory!
          die_cleanly
        fi
-       echo `pwd`
+	   $(pwd)
        ;;
     r) POST2REFORMAT="${OPTARG}"
        ;;
@@ -515,13 +515,13 @@ done
   fi 
 
   if [ ${POST2EDIT} -ge 1 ]; then
-    LATEST=`get_path2post ${POST2EDIT}`
+	LATEST=$(get_path2post ${POST2EDIT})
     ${EDITOR} ${DIR}/${LATEST}.raw
     POST2REFORMAT="${POST2EDIT}"
   fi
 
   if [ ${POST2REFORMAT} -ge 1 ]; then
-    LATEST=`get_path2post ${POST2REFORMAT}`
+	LATEST=$(get_path2post ${POST2REFORMAT})
     reformat_singleton "${LATEST}"
     die_cleanly
   fi

--- a/bin/vee-rebuild
+++ b/bin/vee-rebuild
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-GENDATE=`date`
+GENDATE=$(date)
 VEEDIR=./.vee
 HTMLEXT=html
 
@@ -45,28 +45,28 @@ echo "<!-- ;100000000000000000000000; more HTML -->"
 echo "<!-- ;10000000000000000000000; new index regenerated on $GENDATE -->"
 echo "<!-- ;1000000000000000000000; pre tag --><pre>"
 
-for f in `veels`; 
+for f in $(veels); 
 do
     # title is the 3rd line
-    TITLE=`echo $f | veecat -t`
+	TITLE=$(echo $f | veecat -t)
 
     # full date string (not epoch) is the first line
-    DATE=`echo $f | veecat -d`
+	DATE=$(echo $f | veecat -d)
 
     # deal with with timezone info in a brutish way (seems like a TZ mismatch in data input will cause error)
-    TZ_SYS=`date "+%Z"`
-    DOW=`echo $DATE | awk '{ print $1 }'`
-    MON=`echo $DATE | awk '{ print $2 }'`
-    DOM=`echo $DATE | awk '{ print $3 }'`
-    HMS=`echo $DATE | awk '{ print $4 }'`
-    TZN=`echo $DATE | awk '{ print $5 }'`
-     YR=`echo $DATE | awk '{ print $6 }'`
+	TZ_SYS=$(date "+%Z")
+	DOW=$(echo $DATE | awk '{ print $1 }')
+	MON=$(echo $DATE | awk '{ print $2 }')
+	DOM=$(echo $DATE | awk '{ print $3 }')
+	HMS=$(echo $DATE | awk '{ print $4 }')
+	TZN=$(echo $DATE | awk '{ print $5 }')
+	YR=$(echo $DATE | awk '{ print $6 }')
 
     # reformate date for indexing purposes (.raw files untouched)
-    FORMATTED_DATE=`date -d"$DATE" +%m/%d/%Y`
+	FORMATTED_DATE=$(date -d"$DATE" +%m/%d/%Y)
 
     # get epoch for purpose of adding reasonable post index numbers 
-    EPOCH=`date -d"$DATE" "+%s"` 
+	EPOCH=$(date -d"$DATE" "+%s") 
 
     # extract base name of .raw file so we can link to html file of same base
     FILENAME=$(basename $f)

--- a/bin/veecat
+++ b/bin/veecat
@@ -22,34 +22,34 @@ IFS=
 
  get_title()
 {
-    TITLE=`head -n 3 $1 | tail -n 1`
+	TITLE=$(head -n 3 $1 | tail -n 1)
     echo $TITLE
 }
 
  get_date()
 {
-    DATE=`head -n 1 $1`
+	DATE=$(head -n 1 $1)
     echo $DATE
 }
 
  get_header()
 {
     # get line one through line 5, the entire header w/o separator
-    echo `cat $1 | head -n 5`
+	echo $(cat $1 | head -n 5)
 }
 
  get_body()
 {
-    # figure out how many lones file is for `tail` command
-    LC=`wc -l $1 | awk '{print $1}'`
+	# figure out how many lones file is for $(tail) command
+	LC=$(wc -l $1 | awk '{print $1}')
     BC=$(($LC-6))
-    echo `cat $1 | tail -n $BC`
+	$(cat $1 | tail -n $BC)
     
 }
 
  get_all() 
 {
-    echo `cat $1`
+	cat $1
 }
 
  die_error()
@@ -91,16 +91,16 @@ while read -r IN <&0 ; do
   if [ -e "${IN}" ]; then
       # assumes file is a proper *.raw , else GIGO
       if [ $SHOWALL -eq 1 ]; then
-          echo `get_all "${IN}"`
+			echo $(get_all "${IN}")
       else
           if [ $SHOWTITLE -eq 1 ]; then
-            echo `get_title "${IN}"`
+			echo $(get_title "${IN}")
           fi
           if [ $SHOWDATE -eq 1 ]; then
-            echo `get_date "${IN}"`
+			echo $(get_date "${IN}")
           fi 
           if [ $SHOWBODY -eq 1 ]; then
-            echo `get_body "${IN}"`
+			echo $(get_body "${IN}")
           fi
       fi
   fi

--- a/bin/veels
+++ b/bin/veels
@@ -62,13 +62,13 @@ done
 
  get_title()
 {
-    TITLE=`head -n 3 $1 | tail -n 1`
+	TITLE=$(head -n 3 $1 | tail -n 1)
     echo $TITLE
 }
 
  get_date()
 {
-    DATE=`head -n 1 $1`
+	DATE=$(head -n 1 $1)
     echo $DATE
 }
 
@@ -79,17 +79,17 @@ done
 
 #-- main program body
 
-#-- read config, `pwd`/.veerc (happens after "-d" so it's consistent
+#-- read config, $(pwd)/.veerc (happens after "-d" so it's consistent
 #--      with how bin/vee does it)
 read_config   
 
-for f in `get_sorted`; 
+for f in $(get_sorted); 
 do
     # title is the 3rd line
-    TITLE=`get_title "$f"`
+	TITLE=$(get_title "$f")
 
     # full date string (not epoch) is the first line
-    DATE=`get_date "$f"`
+	DATE=$(get_date "$f")
 
     if [ 1 -eq $USELS ]; then
         _ls "$f"


### PR DESCRIPTION
The backquote (`) is used in the old-style command substitution, e.g. foo=`command`. The foo=$(command) syntax is recommended instead. Backslash handling inside $() is less surprising, and $() is easier to nest. See http://mywiki.wooledge.org/BashFAQ/082
