### PR TITLE
Revert "Simplify `read -r` argument"

### DIFF
--- a/bin/vee
+++ b/bin/vee
@@ -545,9 +545,9 @@ done
 
   if [ $LISTENSTDIN -eq 1 ]; then
     IFS="" # ensures that leading spaces are retained
-    while read -r <&0 ; do # break after 1 sec of no stdin
-      echo "$REPLY"            # echo's stdin back out so user can see 
-      echo "$REPLY" >> "$DRAFT" 
+    while read -r IN <&0 ; do # break after 1 sec of no stdin
+      echo "$IN"            # echo's stdin back out so user can see 
+      echo "$IN" >> "$DRAFT" 
       LISTENSTDIN=1
       USE_EDITOR=0
     done

--- a/bin/veecat
+++ b/bin/veecat
@@ -86,21 +86,21 @@ if [ $SHOWTITLE -eq 1 ] && [ $SHOWDATE -eq 1 ] && [ $SHOWBODY -eq 1 ]; then
     SHOWALL=1
 fi
 
-while read -r <&0 ; do 
+while read -r IN <&0 ; do 
   # make sure file exists, else just ignore line (more Unix-y this way)
-  if [ -e "$REPLY" ]; then
+  if [ -e "$IN" ]; then
       # assumes file is a proper *.raw , else GIGO
       if [ $SHOWALL -eq 1 ]; then
-			echo $(get_all "$REPLY")
+			echo $(get_all "$IN")
       else
           if [ $SHOWTITLE -eq 1 ]; then
-			echo $(get_title "$REPLY")
+			echo $(get_title "$IN")
           fi
           if [ $SHOWDATE -eq 1 ]; then
-			echo $(get_date "$REPLY")
+			echo $(get_date "$IN")
           fi 
           if [ $SHOWBODY -eq 1 ]; then
-			echo $(get_body "$REPLY")
+			echo $(get_body "$IN")
           fi
       fi
   fi


### PR DESCRIPTION
Reverts estrabd/vee#22

On my test machines, REPLY is required, I am not sure why. Because of this, it doesn't make much sense to simply be renaming the variable.
